### PR TITLE
Add `repomix-output.xml` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
+repomix-output.xml
 storage/

--- a/project-words.txt
+++ b/project-words.txt
@@ -9,6 +9,7 @@ nosniff
 NUXT
 privkey
 publickey
+repomix
 rwxr
 SAMEORIGIN
 secp


### PR DESCRIPTION
We want to keep it to give context to LLMs but without pushing it into the repo.